### PR TITLE
Fix for running on multiple units

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -60,7 +60,7 @@ class MosquitoSpeak(MycroftSkill):
         self.uuid = manager.Value(c_char_p, str(uuid.uuid1()))
         self.last_message = manager.Value(c_char_p, "There is no last message")
 
-        client = mqtt.Client()
+        client = mqtt.Client('mycroft_' + self.room_name)  # use self.room_name from home.mycroft.ai to provide a unique device name
 
         client.on_connect = self.on_connect
         client.on_message = self.on_message
@@ -95,6 +95,12 @@ class MosquitoSpeak(MycroftSkill):
     def stop(self):
         pass
 
+    # from steve-mycroft wink skill
+    @property	
+    def room_name(self):
+        # assume the "name" of the device is the "room name"
+        device = DeviceApi().get()
+        return device['description'].replace(' ', '_')
 
 def create_skill():
     return MosquitoSpeak()

--- a/__init__.py
+++ b/__init__.py
@@ -27,6 +27,7 @@ from ctypes import c_char_p
 import uuid
 import time
 import re
+from mycroft.api import DeviceApi
 
 __author__ = 'cagerskov'
 


### PR DESCRIPTION
When running this skill on multiple 'mycroft' devices, only one receives the mqtt message to speak. It appears that the last unit to refresh/reload the skill is the one that receives the message. I believe it is caused by not having a unique client id for each 'mycroft' device that connects to the mqtt server. This pull request provides some code to provide a unique identifier based on the assumption that a device is given a unique description when registered on home.mycroft.ai (e.g. kitchen/study/bedroom). You may choose to use a different implementation.